### PR TITLE
Setting record root again sets record count again always.

### DIFF
--- a/sip-core/src/main/java/eu/delving/metadata/AnalysisTreeNode.java
+++ b/sip-core/src/main/java/eu/delving/metadata/AnalysisTreeNode.java
@@ -100,7 +100,7 @@ public class AnalysisTreeNode implements AnalysisTree.Node, Serializable {
     public boolean setRecordRoot(Path recordRoot) {
         boolean oldValue = this.recordRoot;
         this.recordRoot = recordRoot != null && getPath().equals(recordRoot);
-        return this.recordRoot != oldValue;
+        return this.recordRoot || this.recordRoot != oldValue;
     }
 
     @Override

--- a/sip-creator/src/main/java/eu/delving/sip/base/VisualFeedback.java
+++ b/sip-creator/src/main/java/eu/delving/sip/base/VisualFeedback.java
@@ -126,7 +126,8 @@ public class VisualFeedback implements Feedback {
         list.ensureIndexIsVisible(listModel.getSize() - 1);
     }
 
-    private void inYourFace(final String message) {
+    private void inYourFace(String message) {
+        message = message.replaceAll("<", "&lt;");
         JOptionPane.showMessageDialog(null, String.format("<html><h3>%s</h3>", message));
     }
 

--- a/sip-creator/src/main/java/eu/delving/sip/files/StorageImpl.java
+++ b/sip-creator/src/main/java/eu/delving/sip/files/StorageImpl.java
@@ -529,7 +529,7 @@ public class StorageImpl extends StorageBase implements Storage {
             catch (Exception e) {
                 File source = new File(here, SOURCE_FILE_NAME);
                 delete(source);
-                throw new StorageException("Unable to convert source", e);
+                throw new StorageException("Unable to convert source: "+e.getMessage(), e);
             }
         }
 

--- a/sip-creator/src/main/java/eu/delving/sip/model/SipModel.java
+++ b/sip-creator/src/main/java/eu/delving/sip/model/SipModel.java
@@ -168,10 +168,10 @@ public class SipModel {
 
     private void clearValidation(RecordMapping recordMapping) {
         try {
-            if (dataSetModel.hasDataSet()) {
+            if (dataSetModel.hasDataSet() && recordMapping != null) {
                 dataSetModel.getDataSet().deleteValidation(recordMapping.getPrefix());
+                feedback.say(String.format("Validation cleared for %s",recordMapping.getPrefix()));
             }
-            feedback.say(String.format("Validation cleared for %s",recordMapping.getPrefix()));
         }
         catch (StorageException e) {
             LOG.warn(String.format("Error while deleting file: %s%n", e));
@@ -388,7 +388,7 @@ public class SipModel {
 
             @Override
             public void failure(Exception exception) {
-                feedback.alert("Analysis failed", exception);
+                feedback.alert("Analysis failed: "+exception.getMessage(), exception);
             }
 
             @Override
@@ -410,7 +410,7 @@ public class SipModel {
                     feedback.say("Source conversion complete");
                 }
                 catch (StorageException e) {
-                    feedback.alert("Conversion failed", e);
+                    feedback.alert("Conversion failed: "+e.getMessage(), e);
                 }
             }
         });

--- a/sip-creator/src/main/java/eu/delving/sip/xml/SourceConverter.java
+++ b/sip-creator/src/main/java/eu/delving/sip/xml/SourceConverter.java
@@ -101,7 +101,7 @@ public class SourceConverter {
                         StartElement start = event.asStartElement();
                         path.push(Tag.create(start.getName().getPrefix(), start.getName().getLocalPart()));
                         if (!recordEvents.isEmpty()) {
-                            if (path.equals(uniqueElementPath)) {
+                            if (path.equals(uniqueElementPath) && uniqueValue == null) {
                                 uniqueBuilder = new StringBuilder();
                                 uniqueValue = null;
                             }
@@ -142,7 +142,7 @@ public class SourceConverter {
                                 }
                             }
                             else {
-                                if (path.equals(uniqueElementPath)) {
+                                if (path.equals(uniqueElementPath) && uniqueBuilder != null) {
                                     uniqueValue = uniqueBuilder.toString();
                                     if (uniqueness.isRepeated(uniqueValue)) {
                                         throw new UniquenessException(uniqueElementPath, count);


### PR DESCRIPTION
Escaping tags for message dialog because they were not appearing (interpreted as html)
Only clearing validation when there is a mapping, not before.
Tolerant to situations where unique id appears more than once in a record (duh).
