### PR TITLE
No longer adding "id" to the index document.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.delving</groupId>
     <artifactId>sip-parent</artifactId>
-    <version>0.4.3-SNAPSHOT</version>
+    <version>0.4.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>SIP-Creator Parent</name>
     <description>

--- a/sip-core/pom.xml
+++ b/sip-core/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>sip-core</artifactId>
     <packaging>jar</packaging>
     <name>SIP-Core</name>
-    <version>0.4.3-SNAPSHOT</version>
+    <version>0.4.4-SNAPSHOT</version>
     <description>
         A Minimal set of classes shared between client and server, avoiding dependency on core module.
     </description>
@@ -69,7 +69,7 @@
     <parent>
         <groupId>eu.delving</groupId>
         <artifactId>sip-parent</artifactId>
-        <version>0.4.3-SNAPSHOT</version>
+        <version>0.4.4-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/sip-core/src/main/java/eu/delving/sip/IndexDocument.java
+++ b/sip-core/src/main/java/eu/delving/sip/IndexDocument.java
@@ -38,7 +38,6 @@ public class IndexDocument {
             if (fieldType == null) fieldType = "text";
             doc.put(String.format("%s_%s_%s", qname.getPrefix(), qname.getLocalPart(), fieldType), value);
             if (definition != null) {
-                if (definition.identifierField) doc.put("id", value);
                 if (definition.summaryField != null) doc.put(definition.summaryField.tag, value);
             }
         }

--- a/sip-creator/pom.xml
+++ b/sip-creator/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>sip-creator</artifactId>
     <packaging>jar</packaging>
     <name>SIP-Creator</name>
-    <version>0.4.3-SNAPSHOT</version>
+    <version>0.4.4-SNAPSHOT</version>
     <inceptionYear>2008</inceptionYear>
 
     <organization>
@@ -66,7 +66,7 @@
     <parent>
         <groupId>eu.delving</groupId>
         <artifactId>sip-parent</artifactId>
-        <version>0.4.3-SNAPSHOT</version>
+        <version>0.4.4-SNAPSHOT</version>
     </parent>
 
     <build>
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>eu.delving</groupId>
             <artifactId>sip-core</artifactId>
-            <version>0.4.3-SNAPSHOT</version>
+            <version>0.4.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.jnlp</groupId>

--- a/sip-creator/src/test/groovy/eu/delving/sip/TestMappingEngine.groovy
+++ b/sip-creator/src/test/groovy/eu/delving/sip/TestMappingEngine.groovy
@@ -99,7 +99,6 @@ class TestMappingEngine {
                 icn_acquisitionMeans_text -> onbekend: schilder
                 icn_acquisitionYear_text -> 1947
                 icn_collectionType_text -> all
-                id -> Princessehof/8A12A315082A345F1A9D3AD14B214CD36D310CF8
                }
             """
             );


### PR DESCRIPTION
NOTE:  version numbers have been bumped from 0.4.3 to 0.4.4 to avoid conflicts, so the same must happen everywhere in the culture-hub!
- dependencies.yml
- SipCreator.scala
- build.xml
