### PR TITLE
StringTemplate, which builds HTML for in various panes, now escapes the ...

### DIFF
--- a/sip-app/src/main/java/eu/delving/sip/base/SwingHelper.java
+++ b/sip-app/src/main/java/eu/delving/sip/base/SwingHelper.java
@@ -21,15 +21,16 @@
 
 package eu.delving.sip.base;
 
+import org.antlr.stringtemplate.AttributeRenderer;
 import org.antlr.stringtemplate.StringTemplate;
 import org.antlr.stringtemplate.StringTemplateGroup;
+import org.apache.commons.lang.StringEscapeUtils;
 
 import javax.jnlp.ServiceManager;
 import javax.jnlp.UnavailableServiceException;
 import javax.swing.*;
 import javax.swing.text.JTextComponent;
-import java.awt.BorderLayout;
-import java.awt.Color;
+import java.awt.*;
 import java.net.URL;
 
 /**
@@ -77,6 +78,10 @@ public class SwingHelper {
     }
 
     private static final StringTemplateGroup STRING_TEMPLATE = new StringTemplateGroup("Templates");
+
+    static {
+        STRING_TEMPLATE.registerRenderer(String.class, new HtmlEncodedRenderer());
+    }
 
     public static StringTemplate getTemplate(String name) {
         return STRING_TEMPLATE.getInstanceOf("st/" + name);
@@ -144,6 +149,31 @@ public class SwingHelper {
         }
         catch (UnavailableServiceException ue) {
             return true;
+        }
+    }
+
+    private static class HtmlEncodedRenderer implements AttributeRenderer {
+        @Override
+        public String toString(Object o) {
+            StringBuilder out = new StringBuilder();
+            for (String line : o.toString().split("\n")) {
+                line = StringEscapeUtils.escapeHtml(line);
+                boolean nonSpace = false;
+                for (char c : line.toCharArray()) {
+                    if (nonSpace) {
+                        out.append(c);
+                    }
+                    else if (c == ' ') {
+                        out.append("&nbsp;");
+                    }
+                    else {
+                        nonSpace = true;
+                        out.append(c);
+                    }
+                }
+                out.append("<br>\n");
+            }
+            return out.toString();
         }
     }
 }


### PR DESCRIPTION
...HTML of its attributes.

So now this kind of stuff renders quite nicely:

```
    <doc tag="@lang">
        <paras>
            <para name="Definition">
                <![CDATA[This attribute is used to specify the language used within individual elements, using the codes from ISO 639-2/b. This is equivalent to authority="iso639-2b" used with the <language> element (which gives a language of the resource described in the record), but is applied to the language used as content of the metadata elements. There is no MARC 21 equivalent for this attribute since language cannot be currently indicated at the element level.]]></para>
            <para name="Examples">
                <![CDATA[
           <name type="personal">
               <namePart type="given">Jack</namePart>
               <namePart type="family">May</namePart>
               <namePart type="termsOfAddress">I</namePart>
               <description lang="eng">District Commissioner</description>
               <description lang="fre">Préfet de région</description>
           </name>
           ]]>
            </para>
        </paras>
    </doc>
```
