### PR TITLE
Added xsi declaration to the output of the mapping engine

### DIFF
--- a/sip-app/src/main/java/eu/delving/sip/xml/XmlOutput.java
+++ b/sip-app/src/main/java/eu/delving/sip/xml/XmlOutput.java
@@ -21,6 +21,8 @@
 
 package eu.delving.sip.xml;
 
+import eu.delving.groovy.DOMBuilder;
+import eu.delving.metadata.RecDef;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -62,7 +64,11 @@ public class XmlOutput {
         for (Map.Entry<String, String> entry : namespaces.entrySet()) {
             namespaceList.add(eventFactory.createNamespace(entry.getKey(), entry.getValue()));
         }
-        namespaceList.add(eventFactory.createNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance"));
+        // TODO find out why they are not added by the DOMBuilder
+        final RecDef.Namespace xsiNamespace = DOMBuilder.XSI_NAMESPACE;
+        final RecDef.Namespace xmlNamespace = DOMBuilder.XML_NAMESPACE;
+        namespaceList.add(eventFactory.createNamespace(xsiNamespace.prefix, xsiNamespace.uri));
+        namespaceList.add(eventFactory.createNamespace(xmlNamespace.prefix, xmlNamespace.uri));
         out.add(eventFactory.createStartElement("", "", OUTPUT_TAG, null, namespaceList.iterator()));
     }
 

--- a/sip-core/src/main/java/eu/delving/groovy/DOMBuilder.java
+++ b/sip-core/src/main/java/eu/delving/groovy/DOMBuilder.java
@@ -49,8 +49,8 @@ public class DOMBuilder extends BuilderSupport {
     public static final String CDATA_BEFORE = "<![CDATA[";
     public static final String CDATA_AFTER = "]]>";
     private static final String SCHEMA_LOCATION_ATTR = "xsi:schemaLocation";
-    private static final RecDef.Namespace XML_NAMESPACE = new RecDef.Namespace("xml", "http://www.w3.org/XML/1998/namespace", null);
-    private static final RecDef.Namespace XSI_NAMESPACE = new RecDef.Namespace("xsi", "http://www.w3.org/2001/XMLSchema-instance", null);
+    public static final RecDef.Namespace XML_NAMESPACE = new RecDef.Namespace("xml", "http://www.w3.org/XML/1998/namespace", null);
+    public static final RecDef.Namespace XSI_NAMESPACE = new RecDef.Namespace("xsi", "http://www.w3.org/2001/XMLSchema-instance", null);
     private Document document;
     private DocumentBuilder documentBuilder;
     private Map<String, RecDef.Namespace> namespaces = new TreeMap<String, RecDef.Namespace>();

--- a/sip-core/src/main/java/eu/delving/groovy/XmlSerializer.java
+++ b/sip-core/src/main/java/eu/delving/groovy/XmlSerializer.java
@@ -21,6 +21,7 @@
 
 package eu.delving.groovy;
 
+import eu.delving.metadata.RecDef;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -62,8 +63,11 @@ public class XmlSerializer {
                 if (entry.getValue().trim().isEmpty()) continue;
                 nslist.add(eventFactory.createNamespace(entry.getKey(), entry.getValue()));
             }
-            // add xsi declaration
-            nslist.add(eventFactory.createNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance"));
+            // TODO find out why they are not added by the DOMBuilder
+            final RecDef.Namespace xsiNamespace = DOMBuilder.XSI_NAMESPACE;
+            final RecDef.Namespace xmlNamespace = DOMBuilder.XML_NAMESPACE;
+            nslist.add(eventFactory.createNamespace(xsiNamespace.prefix, xsiNamespace.uri));
+            nslist.add(eventFactory.createNamespace(xmlNamespace.prefix, xmlNamespace.uri));
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             XMLEventWriter out = outputFactory.createXMLEventWriter(new OutputStreamWriter(outputStream, "UTF-8"));
             out.add(eventFactory.createStartDocument());


### PR DESCRIPTION
The consumer of the mapping engine needs a declaration at the root of xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance". 

I have  added it to both the XMLSerializer and to the XMLOutput. If a better solution can be thought up please implement it is this branch.

Currently, this breaks all full-views in the culture-hub
