### PR TITLE
duplicate leaf elements, serializer character encoding

### DIFF
--- a/sip-core/src/main/java/eu/delving/groovy/XmlSerializer.java
+++ b/sip-core/src/main/java/eu/delving/groovy/XmlSerializer.java
@@ -111,7 +111,7 @@ public class XmlSerializer {
             if (fromMapping) out.add(eventFactory.createCharacters("\n"));
             out.add(eventFactory.createEndDocument());
             out.flush();
-            return new String(outputStream.toByteArray());
+            return new String(outputStream.toByteArray(), "UTF-8");
         }
         catch (XMLStreamException e) {
             throw new RuntimeException(e);

--- a/sip-core/src/main/java/eu/delving/metadata/RecDefNode.java
+++ b/sip-core/src/main/java/eu/delving/metadata/RecDefNode.java
@@ -195,7 +195,7 @@ public class RecDefNode implements Comparable<RecDefNode> {
     }
 
     public boolean isDuplicatePossible() {
-        return parent != null && !isLeafElem() && !isAttr() && (optBox == null || optBox.role == DYNAMIC);
+        return parent != null && !isAttr() && (optBox == null || optBox.role == DYNAMIC);
     }
 
     public boolean isHiddenOpt(OptList.Opt shownOpt) {


### PR DESCRIPTION
XmlSerializer now outputs a string with the right character encoding.
