### PR TITLE
Defensive about making prefix choices during switch.

### DIFF
--- a/sip-app/src/main/java/eu/delving/sip/Application.java
+++ b/sip-app/src/main/java/eu/delving/sip/Application.java
@@ -406,13 +406,8 @@ public class Application {
         @Override
         public void run() {
             File storageDirectory;
-            if (application != null) {
-                application.destroy();
-                storageDirectory = storageFinder.getStorageDirectory(application.storageDirectory);
-            }
-            else {
-                storageDirectory = storageFinder.getStorageDirectory(null);
-            }
+            if (application != null) application.destroy();
+            storageDirectory = storageFinder.getStorageDirectory();
             if (storageDirectory == null) {
                 System.exit(0);
             }

--- a/sip-app/src/main/java/eu/delving/sip/actions/SelectAnotherMappingAction.java
+++ b/sip-app/src/main/java/eu/delving/sip/actions/SelectAnotherMappingAction.java
@@ -28,7 +28,7 @@ import eu.delving.sip.model.MappingModel;
 import eu.delving.sip.model.SipModel;
 
 import javax.swing.*;
-import java.awt.*;
+import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
@@ -90,13 +90,18 @@ public class SelectAnotherMappingAction extends AbstractAction implements Work {
 
     @Override
     public void run() {
-        if (choices.size() == 1) {
-            sipModel.setDataSetPrefix(sipModel.getDataSetModel().getDataSet(), choices.get(0).getPrefix(), null);
-        }
-        else {
-            String prefix = askForPrefix(choices);
-            if (prefix == null) return;
-            sipModel.setDataSetPrefix(sipModel.getDataSetModel().getDataSet(), prefix, null);
+        switch (choices.size()) {
+            case 0:
+                // nothing to do, strange situation in the first place
+                break;
+            case 1:
+                sipModel.setDataSetPrefix(sipModel.getDataSetModel().getDataSet(), choices.get(0).getPrefix(), null);
+                break;
+            default:
+                String prefix = askForPrefix(choices);
+                if (prefix == null) return;
+                sipModel.setDataSetPrefix(sipModel.getDataSetModel().getDataSet(), prefix, null);
+                break;
         }
     }
 
@@ -115,7 +120,14 @@ public class SelectAnotherMappingAction extends AbstractAction implements Work {
             buttonGroup.add(b);
             buttonPanel.add(b);
         }
-        return sipModel.getFeedback().form("Choose Schema", buttonPanel) ? buttonGroup.getSelection().getActionCommand() : null;
+        if (!sipModel.getFeedback().form("Choose Schema", buttonPanel)) {
+            return null;
+        }
+        ButtonModel selection = buttonGroup.getSelection();
+        if (selection == null) {
+            return null;
+        }
+        return selection.getActionCommand();
     }
 
 }

--- a/sip-app/src/main/java/eu/delving/sip/files/StorageFinder.java
+++ b/sip-app/src/main/java/eu/delving/sip/files/StorageFinder.java
@@ -76,7 +76,7 @@ public class StorageFinder {
         this.args = args;
     }
 
-    public File getStorageDirectory(File unwanted) {
+    public File getStorageDirectory() {
         if (args.length == 1 && args[0].equals(STANDALONE_DIR)) {
             return new File(WORKSPACE_DIR, STANDALONE_DIR);
         }
@@ -86,7 +86,7 @@ public class StorageFinder {
             case 1:
                 return storageDirs.get(0);
             default:
-                return chooseDirectory(storageDirs, unwanted);
+                return chooseDirectory(storageDirs);
         }
     }
 
@@ -196,10 +196,9 @@ public class StorageFinder {
         }
     }
 
-    private static File chooseDirectory(List<File> directories, File unwanted) {
+    private static File chooseDirectory(List<File> directories) {
         List<String> selectable = new ArrayList<String>();
         for (File directory : directories) {
-            if (unwanted != null && directory.getName().equals(unwanted.getName())) continue;
             if (!(STANDALONE_DIR.equals(directory.getName()) || HPU_DIRECTORY.matcher(directory.getName()).find())) continue;
             selectable.add(directory.getName());
         }

--- a/sip-core/src/main/java/eu/delving/XStreamFactory.java
+++ b/sip-core/src/main/java/eu/delving/XStreamFactory.java
@@ -22,6 +22,7 @@ public class XStreamFactory {
     private static XStream getStream() {
         XStream stream = new XStream(new PureJavaReflectionProvider());
         stream.setMode(XStream.NO_REFERENCES);
+        stream.setMode(XStream.XPATH_ABSOLUTE_REFERENCES);
         stream.registerConverter(new Tag.Converter());
         stream.registerConverter(new Path.Converter());
         return stream;


### PR DESCRIPTION
Avoiding <path reference="../../../recordStats/frequency-within-record/entry[3]/path"/> with XStream mode flag
Restart allowing for restarting the same directory
