### PR TITLE
ValueNode splitting by pipe as Operator.

### DIFF
--- a/sip-core/src/main/java/eu/delving/metadata/Operator.java
+++ b/sip-core/src/main/java/eu/delving/metadata/Operator.java
@@ -33,6 +33,7 @@ public enum Operator {
     COMMA_DELIM("Comma-Delimited", "* ', ' *"),
     SEMI_DELIM("Semicolon-Delimited", "* '; ' *"),
     SPACE_DELIM("Space-Delimited", "* ' ' *"),
+    PIPE_DELIM("Pipe-Delimited", "* '|' * "),
     AS_ARRAY("As-Array", ">>");
 
     private final String display;


### PR DESCRIPTION
The Mais-Flexis Archival system exports repeating fields as pipe separated, i.e. `|`. 

This means that the data needs to be split at the record level in order to be processed into separate fields.

This pull-requests adds the following:

* `Pipe-Delimited` in the 'code-tweaking' interface
* Groovy script recognizes the various split options  `Operator.java`
* Splitting into "@resource" attribute duplicates target fields similar to how literals are treated. 