### PR TITLE
Escape single quotes and restore former getValueNodes behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+### Fixed
+
+- Escape single quotes and restore former getValueNodes behavior [[GH-513]](https://github.com/delving/sip-creator/pull/513)
+
 - history of changes: see https://github.com/delving/sip-creator/compare/sip-creator-v1.2.2...master
 
 ## v1.2.2 (2021-09-16)

--- a/sip-core/src/main/java/eu/delving/groovy/GroovyCodeResource.java
+++ b/sip-core/src/main/java/eu/delving/groovy/GroovyCodeResource.java
@@ -62,7 +62,7 @@ public class GroovyCodeResource {
         for (Map.Entry<String,String> entry : facts.entrySet()) {
             String value = entry.getValue();
             if (value != null) {
-                value = value.replace("'", "\'");
+                value = value.replace("'", "\\'");
             }
             scriptCode.append(String.format("String %s = '''%s'''%n", entry.getKey(), value));
         }

--- a/sip-core/src/main/java/eu/delving/groovy/GroovyNode.java
+++ b/sip-core/src/main/java/eu/delving/groovy/GroovyNode.java
@@ -208,18 +208,12 @@ public class GroovyNode {
     }
 
     private void getValueNodes(String name, List answer) {
-        if (nodeValue instanceof List) {
-            for (Object object : ((List) nodeValue)) {
-                if (object instanceof GroovyNode) {
-                    ((GroovyNode) object).getValueNodes(name, answer);
-                }
-                else {
-                    getValueNodes(name, (List) object);
-                }
-            }
+        if (name.equals(this.getNodeName())) {
+            if (text != null && !text.isEmpty()) answer.add(this);
         }
-        else if (name.equals(this.getNodeName())) {
-            if (nodeValue instanceof String && !((String) nodeValue).trim().isEmpty()) answer.add(this);
+
+        for (GroovyNode child : children) {
+            child.getValueNodes(name, answer);
         }
     }
 


### PR DESCRIPTION
Escape single quotes was required to support single quotes in provider names, e.g. "heemkundekring 'de oude schoenendoos'" would cause errors in the groovy script.

`getValueNodes` inside a groovyscript sholud traverse the whole tree to gather valuesnodes. This is a fix to revert previous behaviour.