### PR TITLE
Feature/add nant support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## unreleased
+ 
+- history of changes: see https://github.com/delving/sip-creator/compare/sip-creator-v1.2.3...master
+
+## v1.2.3 (2022-01-05)
+
+### Added
+
+- Add support for NANT record-definition [[GH-514]](https://github.com/delving/sip-creator/pull/514)
 
 ### Fixed
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.delving</groupId>
     <artifactId>sip-creator</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
     <packaging>pom</packaging>
     <name>SIP-Creator</name>
     <description>This parent project defines the version management, repositories, etc for all the other modules.</description>

--- a/sip-app/pom.xml
+++ b/sip-app/pom.xml
@@ -30,11 +30,11 @@
     <artifactId>sip-app</artifactId>
     <packaging>jar</packaging>
     <name>SIP-App</name>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <parent>
         <groupId>eu.delving</groupId>
         <artifactId>sip-creator</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.3</version>
     </parent>
 
     <build>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>eu.delving</groupId>
             <artifactId>sip-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>com.jgoodies</groupId>

--- a/sip-core/pom.xml
+++ b/sip-core/pom.xml
@@ -24,11 +24,11 @@
     <artifactId>sip-core</artifactId>
     <packaging>jar</packaging>
     <name>SIP-Core</name>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
     <parent>
         <groupId>eu.delving</groupId>
         <artifactId>sip-creator</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.3</version>
     </parent>
     <dependencies>
         <dependency>

--- a/sip-core/src/main/java/eu/delving/metadata/MappingResult.java
+++ b/sip-core/src/main/java/eu/delving/metadata/MappingResult.java
@@ -115,7 +115,7 @@ public class MappingResult {
 
     public String toRDF() {
         String rdf = toString();
-        rdf = rdf.replaceAll("naa:RDF|edm:RDF", "rdf:RDF");
+        rdf = rdf.replaceAll("naa:RDF|edm:RDF|nant:RDF", "rdf:RDF");
         rdf = rdf.replaceAll(" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"", "");
         rdf = rdf.replaceAll("<rdf:RDF ", "$0xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" ");
         return rdf;


### PR DESCRIPTION
Some record-definitions require a special rewrite on the RDF-XML output. The new NANT record-definition for the Dutch National Archive requires this change.

This pull request adds the nant-record definition exception and bumps the version number to 1.2.3.