### PR TITLE
Feature/make writing pocket output files optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
  
 - history of changes: see https://github.com/delving/sip-creator/compare/sip-creator-v1.2.3...master
 
+## v1.2.4 (2022-01-20)
+
+### Fixed
+
+- make output files while validation in sip-app optional [[GH-515]](https://github.com/delving/sip-creator/pull/515)
+
+- history of changes: see https://github.com/delving/sip-creator/compare/sip-creator-v1.2.3...v1.2.4
+
 ## v1.2.3 (2022-01-05)
 
 ### Added
@@ -14,7 +22,7 @@
 
 - Escape single quotes and restore former getValueNodes behavior [[GH-513]](https://github.com/delving/sip-creator/pull/513)
 
-- history of changes: see https://github.com/delving/sip-creator/compare/sip-creator-v1.2.2...v1.2.
+- history of changes: see https://github.com/delving/sip-creator/compare/sip-creator-v1.2.2...v1.2.3
 
 ## v1.2.2 (2021-09-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - Escape single quotes and restore former getValueNodes behavior [[GH-513]](https://github.com/delving/sip-creator/pull/513)
 
-- history of changes: see https://github.com/delving/sip-creator/compare/sip-creator-v1.2.2...v1.2.3
+- history of changes: see https://github.com/delving/sip-creator/compare/sip-creator-v1.2.2...v1.2.
 
 ## v1.2.2 (2021-09-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - Escape single quotes and restore former getValueNodes behavior [[GH-513]](https://github.com/delving/sip-creator/pull/513)
 
-- history of changes: see https://github.com/delving/sip-creator/compare/sip-creator-v1.2.2...master
+- history of changes: see https://github.com/delving/sip-creator/compare/sip-creator-v1.2.2...v1.2.3
 
 ## v1.2.2 (2021-09-16)
 

--- a/sip-app/pom.xml
+++ b/sip-app/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>eu.delving</groupId>
         <artifactId>sip-creator</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.4</version>
     </parent>
 
     <build>

--- a/sip-app/src/main/java/eu/delving/sip/Application.java
+++ b/sip-app/src/main/java/eu/delving/sip/Application.java
@@ -104,10 +104,13 @@ public class Application {
     private ExpertMenu expertMenu;
     private CreateSipZipAction createSipZipAction;
     private UnlockMappingAction unlockMappingAction;
-    private SipProperties sipProperties;
+    private final static SipProperties sipProperties = new SipProperties();
+
+    public static boolean canWritePocketFiles() {
+        return "true".equals(sipProperties.getProp().getProperty("writePocketFiles"));
+    }
 
     private Application(final File storageDir) throws StorageException {
-        sipProperties = new SipProperties();
         GroovyCodeResource groovyCodeResource = new GroovyCodeResource(getClass().getClassLoader());
         desktop = new JDesktopPane();
         desktop.setMinimumSize(new Dimension(800, 600));

--- a/sip-app/src/main/java/eu/delving/sip/xml/FileProcessor.java
+++ b/sip-app/src/main/java/eu/delving/sip/xml/FileProcessor.java
@@ -23,6 +23,7 @@ package eu.delving.sip.xml;
 
 import eu.delving.groovy.*;
 import eu.delving.metadata.*;
+import eu.delving.sip.Application;
 import eu.delving.sip.base.CancelException;
 import eu.delving.sip.base.ProgressListener;
 import eu.delving.sip.base.Work;
@@ -389,10 +390,12 @@ public class FileProcessor implements Work.DataSetPrefixWork, Work.LongTermWork 
                     validCount++;
                 }
 
-                File outputFile = new File(outputDir, mappingOutput.metadataRecord.getRecordNumber() + ".xml");
-                XmlOutput xmlOutput = new XmlOutput(outputFile, namespaceMap);
-                mappingOutput.record(reportWriter, xmlOutput);
-                xmlOutput.finish(false);
+                if(Application.canWritePocketFiles()) {
+                    File outputFile = new File(outputDir, mappingOutput.metadataRecord.getRecordNumber() + ".xml");
+                    XmlOutput xmlOutput = new XmlOutput(outputFile, namespaceMap);
+                    mappingOutput.record(reportWriter, xmlOutput);
+                    xmlOutput.finish(false);
+                }
             } catch (XMLStreamException | IOException e) {
                 termination.dueToException(e);
             }


### PR DESCRIPTION
By default the mapped files are not written to the output directory when validating.

If you want to enable this you can add `writePocketFiles=true` to the sip-creator.properties file.