### PR TITLE
log record identifier and count on error

### DIFF
--- a/sip-core/src/main/java/eu/delving/groovy/BulkMappingRunner.java
+++ b/sip-core/src/main/java/eu/delving/groovy/BulkMappingRunner.java
@@ -46,7 +46,7 @@ public class BulkMappingRunner extends AbstractMappingRunner {
             if (e.getCause() instanceof DiscardRecordException) {
                 throw (DiscardRecordException) e.getCause();
             }
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to process record(id=" + metadataRecord.getId() + ")", e);
         }
     }
 

--- a/sip-core/src/main/java/eu/delving/groovy/BulkMappingRunner.java
+++ b/sip-core/src/main/java/eu/delving/groovy/BulkMappingRunner.java
@@ -19,7 +19,7 @@ public class BulkMappingRunner extends AbstractMappingRunner {
     private CompiledScript compiledScript;
 
     /**
-     * @param recMapping represents to mapping to be applied
+     * @param recMapping    represents to mapping to be applied
      * @param generatedCode the code to be executed against each record
      */
     public BulkMappingRunner(final RecMapping recMapping, final String generatedCode) {
@@ -46,7 +46,7 @@ public class BulkMappingRunner extends AbstractMappingRunner {
             if (e.getCause() instanceof DiscardRecordException) {
                 throw (DiscardRecordException) e.getCause();
             }
-            throw new RuntimeException("Failed to process record(id=" + metadataRecord.getId() + ")", e);
+            throw new RuntimeException("Failed to process record(id=" + metadataRecord.getId() + ", number=" + metadataRecord.getRecordNumber() + ")", e);
         }
     }
 


### PR DESCRIPTION
When a groovy error occurs, it is not always possible to easily find the record with the error.

This change logs the record index and the record identifier. With this information you can search in the sip-creator for the offending record.