### PR TITLE
RDF validation errors should throw an exception during validation

### DIFF
--- a/sip-app/pom.xml
+++ b/sip-app/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>sip-app</artifactId>
     <packaging>jar</packaging>
     <name>SIP-App</name>
-    <version>1.2.7</version>
+    <version>1.2.8</version>
     <parent>
         <groupId>eu.delving</groupId>
         <artifactId>sip-creator</artifactId>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>eu.delving</groupId>
             <artifactId>sip-core</artifactId>
-            <version>1.2.6</version>
+            <version>1.2.8</version>
         </dependency>
         <dependency>
             <groupId>com.jgoodies</groupId>

--- a/sip-app/src/main/java/eu/delving/sip/xml/FileProcessor.java
+++ b/sip-app/src/main/java/eu/delving/sip/xml/FileProcessor.java
@@ -31,6 +31,8 @@ import eu.delving.sip.files.DataSet;
 import eu.delving.sip.files.ReportWriter;
 import eu.delving.sip.model.Feedback;
 import eu.delving.sip.model.SipModel;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.w3c.dom.Node;
 
 import javax.swing.*;
@@ -38,8 +40,11 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.validation.Validator;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -419,6 +424,7 @@ public class FileProcessor implements Work.DataSetPrefixWork, Work.LongTermWork 
 
                         if (node == null) continue;
                         MappingResult result = new MappingResult(serializer, uriGenerator.generateUri(record.getId()), node, MappingRunner.getRecDefTree());
+                        validateRDF(result);
                         List<String> uriErrors = result.getUriErrors();
                         try {
                             if (!uriErrors.isEmpty()) {
@@ -473,6 +479,12 @@ public class FileProcessor implements Work.DataSetPrefixWork, Work.LongTermWork 
                 isDone = true;
             }
         }
+    }
+
+    private void validateRDF(MappingResult result) {
+        String output = MappingResult.toJenaCompliantRDF(result.toRDF());
+        InputStream in = new ByteArrayInputStream(output.getBytes(StandardCharsets.UTF_8));
+        ModelFactory.createDefaultModel().read(in, null, "RDF/XML");
     }
 
     private enum NextStep {

--- a/sip-app/src/main/java/eu/delving/sip/xml/FileProcessor.java
+++ b/sip-app/src/main/java/eu/delving/sip/xml/FileProcessor.java
@@ -33,6 +33,7 @@ import eu.delving.sip.model.Feedback;
 import eu.delving.sip.model.SipModel;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.RiotException;
 import org.w3c.dom.Node;
 
 import javax.swing.*;
@@ -424,7 +425,7 @@ public class FileProcessor implements Work.DataSetPrefixWork, Work.LongTermWork 
 
                         if (node == null) continue;
                         MappingResult result = new MappingResult(serializer, uriGenerator.generateUri(record.getId()), node, MappingRunner.getRecDefTree());
-                        validateRDF(result);
+                        validateRDF(record, result);
                         List<String> uriErrors = result.getUriErrors();
                         try {
                             if (!uriErrors.isEmpty()) {
@@ -481,10 +482,14 @@ public class FileProcessor implements Work.DataSetPrefixWork, Work.LongTermWork 
         }
     }
 
-    private void validateRDF(MappingResult result) {
-        String output = MappingResult.toJenaCompliantRDF(result.toRDF());
-        InputStream in = new ByteArrayInputStream(output.getBytes(StandardCharsets.UTF_8));
-        ModelFactory.createDefaultModel().read(in, null, "RDF/XML");
+    private void validateRDF(MetadataRecord record, MappingResult result) {
+        try {
+            String output = MappingResult.toJenaCompliantRDF(result.toRDF());
+            InputStream in = new ByteArrayInputStream(output.getBytes(StandardCharsets.UTF_8));
+            ModelFactory.createDefaultModel().read(in, null, "RDF/XML");
+        } catch (RiotException e) {
+            throw new RuntimeException("Error for record(id=" + record.getId() + ", number=" + record.getRecordNumber() + ")", e);
+        }
     }
 
     private enum NextStep {

--- a/sip-core/pom.xml
+++ b/sip-core/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>sip-core</artifactId>
     <packaging>jar</packaging>
     <name>SIP-Core</name>
-    <version>1.2.6</version>
+    <version>1.2.8</version>
     <parent>
         <groupId>eu.delving</groupId>
         <artifactId>sip-creator</artifactId>


### PR DESCRIPTION
Currently, the sip-creator show these errors  but does not throw them during processing. This causes these errors to be only caught when we are transforming them to JSON-LD during saving.