### PR TITLE
Empty template targets are now allowed

### DIFF
--- a/sip-app/pom.xml
+++ b/sip-app/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>eu.delving</groupId>
             <artifactId>sip-core</artifactId>
-            <version>1.2.8</version>
+            <version>1.2.9</version>
         </dependency>
         <dependency>
             <groupId>com.jgoodies</groupId>

--- a/sip-core/pom.xml
+++ b/sip-core/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>sip-core</artifactId>
     <packaging>jar</packaging>
     <name>SIP-Core</name>
-    <version>1.2.8</version>
+    <version>1.2.9</version>
     <parent>
         <groupId>eu.delving</groupId>
         <artifactId>sip-creator</artifactId>


### PR DESCRIPTION
Empty targets would throw errors when reading a record definition. 

This merge request also bumps the version-number of sip-core.